### PR TITLE
Add GitHub Sponsors funding configuration

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: dynamic


### PR DESCRIPTION
This PR adds GitHub Sponsors funding configuration to enable sponsorship for this repository.

## Changes
- Add `.github/FUNDING.yml` with GitHub Sponsors configuration
- Repository will show "Sponsor" button linking to https://github.com/sponsors/dynamic

## Benefits
- Makes it easy for users to financially support ongoing development
- Increases visibility of sponsorship opportunities
- Helps sustain open-source maintenance

The funding configuration follows GitHub's standard format and requires no code changes.