### PR TITLE
Upgrade to SilverStripe 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,11 +18,12 @@
         }
     ],
     "require": {
-        "dnadesign/silverstripe-elemental": "^5.0",
-        "silverstripe/framework": "^5"
+        "php": "^8.3",
+        "dnadesign/silverstripe-elemental": "^6.0",
+        "silverstripe/framework": "^6"
     },
     "require-dev": {
-        "silverstripe/recipe-testing": "^3"
+        "silverstripe/recipe-testing": "^4"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,


### PR DESCRIPTION
Upgrades the module to SilverStripe 6 compatibility.

## Changes

- Updated PHP requirement to ^8.3
- Updated all core dependencies to SS6-compatible versions:
  - `dnadesign/silverstripe-elemental`: ^5 → ^6
  - `silverstripe/framework`: ^5 → ^6
  - `silverstripe/recipe-testing`: ^3 → ^4

## Testing

- ✅ PHPCS: Clean (no violations)
- ✅ No code changes required (no SS6 breaking changes present in codebase)

This prepares the module for the 4.0.0 release.