### PR TITLE
REFACTOR: Remove getType() override to allow extensibility

### DIFF
--- a/src/Elements/ElementStatCounters.php
+++ b/src/Elements/ElementStatCounters.php
@@ -41,12 +41,12 @@ class ElementStatCounters extends BaseElement
     /**
      * @return string
      */
-    private static $singular_name = 'Stat Counters Element';
+    private static $singular_name = 'Stat Counters';
 
     /**
      * @return string
      */
-    private static $plural_name = 'Stat Counters Elements';
+    private static $plural_name = 'Stat Counters Blocks';
 
     /**
      * @var array
@@ -130,13 +130,5 @@ class ElementStatCounters extends BaseElement
         $blockSchema = parent::provideBlockSchema();
         $blockSchema['content'] = $this->getSummary();
         return $blockSchema;
-    }
-
-    /**
-     * @return string
-     */
-    public function getType()
-    {
-        return _t(__CLASS__ . '.BlockType', 'Stat Counters');
     }
 }


### PR DESCRIPTION
## Summary

Remove the `getType()` method override so the element inherits `BaseElement::getType()` which uses `i18n_singular_name()`. This allows sites to customize the element's display name via extensions by setting `$singular_name`.

## Changes

- Removed the `getType()` method from `ElementStatCounters`
- Updated `$singular_name` from `'Stat Counters Element'` to `'Stat Counters'`
- Updated `$plural_name` from `'Stat Counters Elements'` to `'Stat Counters Blocks'`

## Rationale

The base `BaseElement::getType()` implementation already uses `$this->i18n_singular_name()`:

```php
public function getType()
{
    $default = $this->i18n_singular_name() ?: 'Block';
    return _t(static::class . '.BlockType', $default);
}
```

By removing the override, extensions can now customize the display name in the CMS element picker by simply setting `$singular_name`, without needing to override the entire method.

Fixes #19

Related: dynamic/silverstripe-essentials-tools#68