### PR TITLE
Merge SS5 branch (3) into SS6 branch (4)

### DIFF
--- a/src/Elements/ElementStatCounters.php
+++ b/src/Elements/ElementStatCounters.php
@@ -41,12 +41,12 @@ class ElementStatCounters extends BaseElement
     /**
      * @return string
      */
-    private static $singular_name = 'Stat Counters Element';
+    private static $singular_name = 'Stat Counters';
 
     /**
      * @return string
      */
-    private static $plural_name = 'Stat Counters Elements';
+    private static $plural_name = 'Stat Counters Blocks';
 
     /**
      * @var array
@@ -130,13 +130,5 @@ class ElementStatCounters extends BaseElement
         $blockSchema = parent::provideBlockSchema();
         $blockSchema['content'] = $this->getSummary();
         return $blockSchema;
-    }
-
-    /**
-     * @return string
-     */
-    public function getType()
-    {
-        return _t(__CLASS__ . '.BlockType', 'Stat Counters');
     }
 }


### PR DESCRIPTION
## Summary

Merge the SS5 branch into the SS6 branch to bring forward the `getType()` refactor changes.

## Changes from SS5 branch

- Removed `getType()` method override to allow extensibility via `$singular_name`
- Updated `$singular_name` and `$plural_name` values

## Related

- Original SS5 PR: #20
- Parent issue: dynamic/silverstripe-essentials-tools#68