### PR TITLE
fix(#26): make StatCounter Title editable in the inline Stats grid

### DIFF
--- a/src/Elements/ElementStatCounters.php
+++ b/src/Elements/ElementStatCounters.php
@@ -100,6 +100,15 @@ class ElementStatCounters extends BaseElement
                     $addButton = new GridFieldAddNewInlineButton()
                 ]);
 
+                // Explicitly declare the editable columns. Without this,
+                // GridFieldEditableColumns falls back to resolving each column
+                // against the Stat's own getCMSFields(), which other extensions
+                // (e.g. StatCountersExtension) may remove fields from for
+                // unrelated reasons — silently making a saved row's column
+                // read-only instead of editable. Declaring displayFields here
+                // decouples this inline grid from that lookup entirely.
+                $columns->setDisplayFields(StatCounter::singleton()->summaryFields());
+
                 $addButton->setTitle('Add Stat Counter');
 
                 $fields->addFieldToTab('Root.Main', $stats);

--- a/tests/Elements/ElementStatCountersTest.php
+++ b/tests/Elements/ElementStatCountersTest.php
@@ -3,8 +3,12 @@
 namespace Dynamic\Elements\StatCounters\Test\Elements;
 
 use Dynamic\Elements\StatCounters\Elements\ElementStatCounters;
+use Dynamic\Elements\StatCounters\Model\StatCounter;
+use SilverStripe\Control\Controller;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Forms\FieldList;
+use SilverStripe\Forms\Form;
+use Symbiote\GridFieldExtensions\GridFieldEditableColumns;
 
 /**
  * Class ElementStatCountersTest
@@ -25,5 +29,40 @@ class ElementStatCountersTest extends SapphireTest
         $object = $this->objFromFixture(ElementStatCounters::class, 'one');
         $fields = $object->getCMSFields();
         $this->assertInstanceOf(FieldList::class, $fields);
+    }
+
+    /**
+     * Regression test for GH #26: a saved Stat's Title column in the inline
+     * editable grid must render as an editable field, not read-only text.
+     *
+     * Without an explicit setDisplayFields() call, GridFieldEditableColumns
+     * resolves each column for a saved row via the record's own
+     * getCMSFields(), which other extensions applied to StatCounter (e.g.
+     * essentials-tools' StatCountersExtension) may strip fields from for
+     * unrelated reasons - that silently downgrades the column to read-only
+     * instead of throwing, so the previous behaviour looked "fine" but
+     * quietly lost editability. setDisplayFields() bypasses that lookup.
+     */
+    public function testTitleColumnIsEditableForSavedStat()
+    {
+        $element = $this->objFromFixture(ElementStatCounters::class, 'one');
+        $fields = $element->getCMSFields();
+        $stats = $fields->dataFieldByName('Stats');
+        $config = $stats->getConfig();
+        /** @var GridFieldEditableColumns $columns */
+        $columns = $config->getComponentByType(GridFieldEditableColumns::class);
+
+        // Wire the grid into a real Form context, as the CMS would.
+        $form = Form::create(Controller::curr(), 'Form', FieldList::create($stats), FieldList::create());
+        $stats->setForm($form);
+
+        $record = $this->objFromFixture(StatCounter::class, 'one');
+        $html = $columns->getColumnContent($stats, $record, 'Title');
+
+        $this->assertStringContainsString(
+            '<input',
+            $html,
+            'Title column for a saved Stat should render as an editable input, not read-only text'
+        );
     }
 }


### PR DESCRIPTION
## Problem

The Stats grid on `ElementStatCounters` is edited inline (`GridFieldEditableColumns` + `GridFieldAddNewInlineButton`), with no `setDisplayFields()` call. Without it, `GridFieldEditableColumns::getColumnContent()` resolves each saved row's column against the record's own `getCMSFields()`.

Traced empirically (temporary diagnostic test, see PR discussion below): `dynamic/silverstripe-essentials-tools`' `StatCountersExtension` removes the `Title` field from `StatCounter::getCMSFields()` for unrelated reasons (added independently, "not used for display purposes", a premise this issue disproves). That starves the lookup, and the read-only fallback in `GridFieldEditableColumns` kicks in silently, so the Title column renders as plain text instead of an `<input>`.

New (unsaved) rows don't hit this: `GridFieldAddNewInlineButton` scaffolds columns directly from the DB field type, bypassing `getCMSFields()` entirely. This matches the reported symptom exactly (editable on create, read-only after save).

## Fix

Call `$columns->setDisplayFields(StatCounter::singleton()->summaryFields())` in `ElementStatCounters::getCMSFields()`. This makes `GridFieldEditableColumns` resolve columns from its own scaffolded fields (via `getForm()->Fields()`) for both new and saved rows, decoupling the inline grid entirely from `getCMSFields()` and whatever other extensions do there. Column labels are unchanged (same `summaryFields()` source used implicitly before).

## Test plan

- [x] New regression test `testTitleColumnIsEditableForSavedStat`, renders the Title column for a saved fixture Stat via `GridFieldEditableColumns::getColumnContent()` and asserts it's an `<input>`, not read-only text
- [x] Verified the test fails without the fix (`Failed asserting that 'Stat One' contains "<input"`) and passes with it
- [x] `SS_PHPUNIT_FLUSH=1 ddev exec vendor/bin/phpunit vendor/dynamic/silverstripe-elemental-stat-counters/tests`, 7 tests, 7 assertions, all passing
- [x] `phpcs` on changed files: no new violations (identical pre-existing violation count with/without this change)

## Scope note

This fixes only the "Title not editable after save" half of #26. The "disappears after publish" half is a separate ownership/cache-key issue and will land in a follow-up PR. **Not** using "Closes #26" here so the issue stays open until both halves are fixed. Please don't auto-close on merge.

Part of #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)